### PR TITLE
Bug if all fields are empty

### DIFF
--- a/src/FormComponent.php
+++ b/src/FormComponent.php
@@ -70,7 +70,7 @@ class FormComponent extends Component
 
         $field_names = [];
         foreach ($this->fields() as $field) $field_names[] = $field->name;
-        $this->form_data = Arr::only($this->form_data, $field_names);
+        $this->form_data = Arr::only($this->form_data ?? [], $field_names);
 
         $this->success();
     }


### PR DESCRIPTION
If no fields have been filled in (and no fields are required), `$this->form_data = null`, which throws an exception. This fixes that bug